### PR TITLE
Embed Mastodon in a tabbed interface

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -414,8 +414,23 @@ section:target::before {
 
 /* Posts Section
 ------------------------------------- */
-.twitter-timeline {
-  margin: auto;
+.activity-container {
+  width: 90%;
+  max-width: 296px;
+  margin: 0 auto;
+}
+
+.activity-container iframe {
+  width: 100%;
+  max-width: 296px;
+  box-sizing: border-box;
+  border-radius: 3.5%;
+  outline: solid 0.17em rgba(0, 0, 0, 0.02);
+  box-shadow: 0 0.125em 0.25em var(--shadow-color);
+}
+
+.mastodon-viewer iframe {
+  border: solid 1px var(--muted-color);
 }
 
 

--- a/css/style.css
+++ b/css/style.css
@@ -53,7 +53,7 @@ ul {
   margin-bottom: 2em;
 }
 
-a {
+a, button {
   color: var(--linked-color);
   font-family: "Montserrat", sans-serif;
   font-weight: 500;
@@ -431,8 +431,32 @@ section:target::before {
 }
 
 #tab-bar button {
+  color: var(--linked-color);
+  border: solid 1px var(--pale-theme-color);
+  box-shadow: 0 0.125em 0.25em var(--shadow-color);
   flex-grow: 1;
   flex-basis: 0;
+}
+
+#tab-bar button:hover:not(.active) {
+  color: var(--rich-highlighted-color);
+  text-decoration-line: underline;
+  text-decoration-thickness: 0.11em;
+  text-underline-offset: 0.3em;
+  text-decoration-color: var(--rich-highlighted-color);
+  outline: solid 0.08em var(--rich-highlighted-color);
+}
+
+#mastodon-tab-bar.active {
+  color: var(--light-highlighted-color);
+  background-color: #6364ff;
+  text-decoration-line: none;
+}
+
+#twitter-tab-bar.active {
+  color: var(--light-highlighted-color);
+  background-color: #1da1f2;
+  text-decoration-line: none;
 }
 
 #tab-bar-content iframe {

--- a/css/style.css
+++ b/css/style.css
@@ -414,13 +414,28 @@ section:target::before {
 
 /* Posts Section
 ------------------------------------- */
+
+
+
+/* Tab Bar Section
+------------------------------------- */
 .activity-container {
   width: 90%;
   max-width: 296px;
   margin: 0 auto;
 }
 
-.activity-container iframe {
+#tab-bar {
+  display: flex;
+  column-gap: 0.08em;
+}
+
+#tab-bar button {
+  flex-grow: 1;
+  flex-basis: 0;
+}
+
+#tab-bar-content iframe {
   width: 100%;
   max-width: 296px;
   box-sizing: border-box;

--- a/css/style.css
+++ b/css/style.css
@@ -414,7 +414,27 @@ section:target::before {
 
 /* Posts Section
 ------------------------------------- */
+.call-out-container {
+  background-color: var(--bg-tone-color);
+  border: solid 1px var(--pale-theme-color);
+  border-radius: 0.375em;
+  padding: 1em;
+  margin-bottom: 2em;
+}
 
+.call-out-icon {
+  color: var(--accent-color);
+  margin-right: 0.4em;
+}
+
+.call-out-title {
+  border-bottom: solid 1px var(--muted-color);
+  margin-bottom: 0.4em;
+}
+
+.call-out-description {
+  margin-bottom: 0;
+}
 
 
 /* Tab Bar Section

--- a/index.html
+++ b/index.html
@@ -523,6 +523,13 @@
               <p>
                 I share my journey as a developer on both Mastodon and Twitter, so feel free to follow your preferred platform.
               </p>
+              <div class="call-out-container">
+                <p class="call-out-title"><i class="fa-solid fa-bullhorn call-out-icon"></i> Embedded timelines</p>
+                <p class="call-out-description">
+                  Due to changes in the Twitter API, my embedded Twitter may not be visible in your environment.
+                  In that case, please take a look at my embedded Mastodon.
+                </p>
+              </div>
             </div>
 
             <div class="col-md-6 col-sm-12">

--- a/index.html
+++ b/index.html
@@ -527,17 +527,25 @@
 
             <div class="col-md-6 col-sm-12">
               <div class="activity-container">
-
-                <!-- Embedded Mastodon Timeline  -->
-                <div class="mastodon-viewer">
-                  <iframe title="embedding-mastodon" allowfullscreen
-                    sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="296"
-                    height="366"
-                    src="https://www.mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Ffosstodon.org%2Fusers%2Ftentendotz&theme=light&size=85&header=false&replies=true&boosts=true">
-                  </iframe>
+                <!-- Tab Bar -->
+                <div class="nav nav-tabs" id="tab-bar" role="tablist">
+                  <button class="nav-link active" id="mastodon-tab-bar" data-bs-toggle="tab" data-bs-target="#mastodon-tab-pane" type="button" role="tab" aria-controls="mastodon-tab-pane" aria-selected="true">Mastodon</button>
+                  <button class="nav-link" id="twitter-tab-bar" data-bs-toggle="tab" data-bs-target="#twitter-tab-pane" type="button" role="tab" aria-controls="twitter-tab-pane" aria-selected="false">Twitter</button>
                 </div>
-                <!-- Embedded Twitter Timeline  -->
-                <div class="twitter-viewer"></div>
+
+                <!-- Tab Content -->
+                <div class="tab-content" id="tab-bar-content">
+                  <!-- Embedded Mastodon Timeline  -->
+                  <div class="mastodon-viewer tab-pane fade show active" id="mastodon-tab-pane" role="tabpanel" aria-labelledby="mastodon-tab-bar" tabindex="0">
+                    <iframe title="embedding-mastodon" allowfullscreen
+                      sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox"
+                      width="296" height="366"
+                      src="https://www.mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Ffosstodon.org%2Fusers%2Ftentendotz&theme=light&size=85&header=false&replies=true&boosts=true">
+                    </iframe>
+                  </div>
+                  <!-- Embedded Twitter Timeline  -->
+                  <div class="twitter-viewer tab-pane fade" id="twitter-tab-pane" role="tabpanel" aria-labelledby="twitter-tab-bar" tabindex="0"></div>
+                </div>
 
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -578,6 +578,9 @@
               <a href="https://github.com/tentendotz"><i class="fa-brands fa-github"></i> GitHub / @tentendotz</a>
             </li>
             <li>
+              <a href="https://fosstodon.org/@tentendotz"><i class="fa-brands fa-mastodon"></i> Mastodon / @tentendotz (@fosstodon.org)</a>
+            </li>
+            <li>
               <a href="https://twitter.com/tentenblog"><i class="fa-brands fa-x-twitter"></i> Twitter / @tentenblog</a>
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -525,9 +525,21 @@
               </p>
             </div>
 
-            <div class="col-md-6 col-sm-12 activity-container">
-              <!-- Embedded Twitter Timeline  -->
-              <div class="twitter-viewer"></div>
+            <div class="col-md-6 col-sm-12">
+              <div class="activity-container">
+
+                <!-- Embedded Mastodon Timeline  -->
+                <div class="mastodon-viewer">
+                  <iframe title="embedding-mastodon" allowfullscreen
+                    sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="296"
+                    height="366"
+                    src="https://www.mastofeed.com/apiv2/feed?userurl=https%3A%2F%2Ffosstodon.org%2Fusers%2Ftentendotz&theme=light&size=85&header=false&replies=true&boosts=true">
+                  </iframe>
+                </div>
+                <!-- Embedded Twitter Timeline  -->
+                <div class="twitter-viewer"></div>
+
+              </div>
             </div>
 
           </div>

--- a/js/twitter.js
+++ b/js/twitter.js
@@ -29,9 +29,9 @@ const dataSource = {
 
 const options = {
   theme: "light",
-  chrome: "nofooter",
+  chrome: ["noheader", "nofooter"],
   width: 296,
-  height: 416,
+  height: 366,
   tweetLimit: 2
 };
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Linked issue
<!-- Please mention an open issue number, such as #123. -->
<!-- When using the list style, the issue title will be displayed. -->

- Closes #2


### What type of PR is this?
<!-- Please put an `X` on the left side (put all that apply). -->

||PR Type
|---|---------------
| X |✨ New Feature
|   |🐞 Bug Fix
|   |🪄 Enhancement
|   |🛠️ Other



Description
----------------------------------------
<!-- Please do not leave this blank. -->
<!-- This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. -->

#### Workaround for Twitter API changes:
- Implement a tabbed interface to embed both Mastodon and Twitter timelines
- Embed Mastodon timeline using [Mastofeed](https://github.com/fenwick67/mastofeed)
- Include information about the embedded Twitter timeline in a callout box



### Screenshot
<!-- Screenshots or a screen recording are required for visual changes. -->
<!-- If there are no visual changes, please remove this section. -->

|`Before`|`After`|
|:---:|:---:|
|<img width="800" alt="previous-screen" src="https://github.com/tentendotz/tenten-PersonalSite/assets/95609729/c4798999-3561-430a-8e22-95dcf752c098">|<img width="800" alt="new-screen" src="https://github.com/tentendotz/tenten-PersonalSite/assets/95609729/118a4855-df7e-41d3-860e-89d4c676ac71">|





### Additional context
Due to changes in the Twitter API, my embedded Twitter timeline may not be visible in all browsers.  
If a visitor logs out of a Twitter account in the browser, it will likely display "Nothing to see here - yet."

After waiting for six months, there was no sign of change.  
Therefore, I've decided to embed the Mastodon timeline.



### External Links
> [List Widget says “Nothing to see here - yet” if logged out](https://twittercommunity.com/t/again-list-widget-says-nothing-to-see-here-yet-if-logged-out/198782/1)
